### PR TITLE
Update settings.py for Locust load testing configuration

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,21 @@
+import os
+
+DEFAULTS = {'DB_NAME': 'sample',
+            'COLLECTION_NAME': 'documents',
+            'CLUSTER_URL': f'mongodb+srv://user:password@something.mongodb.net/sample?retryWrites=true&w=majority',
+            'DOCS_PER_BATCH': 100,
+            'INSERT_WEIGHT': 1,
+            'FIND_WEIGHT': 3,
+            'BULK_INSERT_WEIGHT': 1,
+            'AGG_PIPE_WEIGHT': 1}
+
+
+def init_defaults_from_env():
+    for key in DEFAULTS.keys():
+        value = os.environ.get(key)
+        if value:
+            DEFAULTS[key] = value
+
+
+# get the settings from the environment variables
+init_defaults_from_env()


### PR DESCRIPTION
In order to update the cluster credentials in the settings.py to match the MongoDB deployment at hand.